### PR TITLE
Adapt usage tracking to new AI SDK token metrics

### DIFF
--- a/app/components/chat/ModelSelector.tsx
+++ b/app/components/chat/ModelSelector.tsx
@@ -92,6 +92,7 @@ export function ModelSelector() {
 
 function ModelOption({ model }: { model: ModelInfo }) {
   const fullId = `${model.provider}:${model.id}`;
+  const pricing = model.pricing;
 
   return (
     <Select.Item
@@ -116,7 +117,9 @@ function ModelOption({ model }: { model: ModelInfo }) {
           <div className="flex items-center gap-2 mt-1">
             <ModelCapabilityBadges model={model} />
             <span className="text-xs text-bolt-elements-textTertiary">
-              ${model.pricing.input.toFixed(2)}/${model.pricing.output.toFixed(2)} per 1M tokens
+              {pricing
+                ? `$${pricing.input.toFixed(2)}/${pricing.output.toFixed(2)} per 1M tokens`
+                : 'Pricing unavailable'}
             </span>
           </div>
         </div>

--- a/app/components/chat/UsageStats.tsx
+++ b/app/components/chat/UsageStats.tsx
@@ -1,9 +1,9 @@
 import { useStore } from '@nanostores/react';
 import { motion } from 'framer-motion';
-import { Coins, MessageSquare,FileOutput } from 'lucide-react';
+import { Coins, MessageSquare, FileOutput } from 'lucide-react';
+import { Tooltip } from '~/components/ui/Tooltip';
 import { $sessionUsage } from '~/lib/stores/usage';
 import { formatNumber } from '~/utils/format';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '~/components/ui/Tooltip';
 
 export function UsageStats() {
   const usage = useStore($sessionUsage);
@@ -20,47 +20,26 @@ export function UsageStats() {
       transition={{ duration: 0.3 }}
       className="flex items-center gap-4 text-xs text-bolt-elements-textSecondary"
     >
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <div className="flex items-center gap-1.5">
-              <MessageSquare className="w-3.5 h-3.5" />
-              <span>{formatNumber(tokens.input)}</span>
-            </div>
-          </TooltipTrigger>
-          <TooltipContent>
-            <p>Input Tokens</p>
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+      <Tooltip content={<p>Input Tokens</p>}>
+        <div className="flex items-center gap-1.5">
+          <MessageSquare className="w-3.5 h-3.5" />
+          <span>{formatNumber(tokens.input)}</span>
+        </div>
+      </Tooltip>
 
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <div className="flex items-center gap-1.5">
-              <FileOutput className="w-3.5 h-3.5" />
-              <span>{formatNumber(tokens.output)}</span>
-            </div>
-          </TooltipTrigger>
-          <TooltipContent>
-            <p>Output Tokens</p>
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+      <Tooltip content={<p>Output Tokens</p>}>
+        <div className="flex items-center gap-1.5">
+          <FileOutput className="w-3.5 h-3.5" />
+          <span>{formatNumber(tokens.output)}</span>
+        </div>
+      </Tooltip>
 
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <div className="flex items-center gap-1.5">
-              <Coins className="w-3.5 h-3.5" />
-              <span>${cost.toFixed(4)}</span>
-            </div>
-          </TooltipTrigger>
-          <TooltipContent>
-            <p>Session Cost</p>
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+      <Tooltip content={<p>Session Cost</p>}>
+        <div className="flex items-center gap-1.5">
+          <Coins className="w-3.5 h-3.5" />
+          <span>${cost.toFixed(4)}</span>
+        </div>
+      </Tooltip>
     </motion.div>
   );
 }

--- a/app/lib/.server/llm/cost-calculator.test.ts
+++ b/app/lib/.server/llm/cost-calculator.test.ts
@@ -6,7 +6,8 @@ describe('calculateCost', () => {
   const mockModelWithPricing: ModelInfo = {
     id: 'test-model',
     name: 'Test Model',
-    provider: 'test',
+    description: 'Mock model with pricing',
+    provider: 'anthropic',
     pricing: {
       input: 1.0, // $1 per 1M input tokens
       output: 2.0, // $2 per 1M output tokens
@@ -21,7 +22,8 @@ describe('calculateCost', () => {
   const mockModelWithoutPricing: ModelInfo = {
     id: 'free-model',
     name: 'Free Model',
-    provider: 'test',
+    description: 'Mock model without pricing',
+    provider: 'anthropic',
     contextWindow: 4096,
     maxTokens: 1024,
     capabilities: {

--- a/app/lib/.server/llm/providers/types.ts
+++ b/app/lib/.server/llm/providers/types.ts
@@ -65,7 +65,7 @@ export interface ModelInfo {
   capabilities: ModelCapabilities;
 
   /** Pricing information */
-  pricing: ModelPricing;
+  pricing?: ModelPricing;
 
   /** Is this the default model for the provider? */
   isDefault?: boolean;

--- a/app/lib/persistence/db.ts
+++ b/app/lib/persistence/db.ts
@@ -7,6 +7,20 @@ const logger = createScopedLogger('ChatHistory');
 
 export type SessionUsageWithTimestamp = SessionUsage & { timestamp: string };
 
+let dbPromise: Promise<IDBDatabase | undefined> | undefined;
+
+export async function getDatabase(): Promise<IDBDatabase | undefined> {
+  if (typeof window === 'undefined') {
+    return undefined;
+  }
+
+  if (!dbPromise) {
+    dbPromise = openDatabase();
+  }
+
+  return dbPromise;
+}
+
 // this is used at the top level and never rejects
 export async function openDatabase(): Promise<IDBDatabase | undefined> {
   return new Promise((resolve) => {

--- a/app/lib/stores/usage.ts
+++ b/app/lib/stores/usage.ts
@@ -23,25 +23,30 @@ export const $sessionUsage = map<SessionUsage>({
 export const $totalUsage = atom<SessionUsage[]>([]);
 
 export function addUsage(usage: {
-  promptTokens: number;
-  completionTokens: number;
+  inputTokens?: number | null;
+  outputTokens?: number | null;
   cost?: number | null;
   provider?: string;
   modelId?: string;
 }) {
   const current = $sessionUsage.get();
+  const inputTokens = usage.inputTokens ?? 0;
+  const outputTokens = usage.outputTokens ?? 0;
+
   $sessionUsage.setKey('tokens', {
-    input: current.tokens.input + usage.promptTokens,
-    output: current.tokens.output + usage.completionTokens,
+    input: current.tokens.input + inputTokens,
+    output: current.tokens.output + outputTokens,
   });
 
-  if (usage.cost) {
+  if (typeof usage.cost === 'number') {
     $sessionUsage.setKey('cost', current.cost + usage.cost);
   }
-  if(usage.provider) {
+
+  if (usage.provider) {
     $sessionUsage.setKey('provider', usage.provider);
   }
-    if(usage.modelId) {
+
+  if (usage.modelId) {
     $sessionUsage.setKey('modelId', usage.modelId);
   }
 }

--- a/app/routes/api.chat.ts
+++ b/app/routes/api.chat.ts
@@ -51,7 +51,11 @@ async function chatAction({ context, request }: ActionFunctionArgs) {
       messages.push({ role: 'user', content: CONTINUE_PROMPT });
 
       const continued = await streamText(messages, context.cloudflare.env, streamOptions);
-      const continuedResp = continued.toUIMessageStreamResponse({ sendStart: false });
+      const continuedResp = continued.toUIMessageStreamResponse({
+        sendStart: false,
+        sendFinish: true,
+        messageMetadata: (args) => continued.usageMetadata(args),
+      });
 
       return stream.switchSource(continuedResp.body!);
     };
@@ -66,7 +70,10 @@ async function chatAction({ context, request }: ActionFunctionArgs) {
     options.onFinish = createOnFinishHandler(options);
 
     const result = await streamText(messages, context.cloudflare.env, options);
-    const resp = result.toUIMessageStreamResponse({ sendFinish: false });
+    const resp = result.toUIMessageStreamResponse({
+      sendFinish: true,
+      messageMetadata: (args) => result.usageMetadata(args),
+    });
 
     await stream.switchSource(resp.body!);
 
@@ -97,7 +104,10 @@ async function chatAction({ context, request }: ActionFunctionArgs) {
           fallbackOptions.onFinish = createOnFinishHandler(fallbackOptions);
 
           const result = await streamText(messages, context.cloudflare.env, fallbackOptions);
-          const resp = result.toUIMessageStreamResponse({ sendFinish: false });
+          const resp = result.toUIMessageStreamResponse({
+            sendFinish: true,
+            messageMetadata: (args) => result.usageMetadata(args),
+          });
 
           await stream.switchSource(resp.body!);
 

--- a/app/types/model.ts
+++ b/app/types/model.ts
@@ -26,7 +26,7 @@ export interface ModelInfo {
   maxTokens: number;
   contextWindow: number;
   capabilities: ModelCapabilities;
-  pricing: ModelPricing;
+  pricing?: ModelPricing;
   isDefault?: boolean;
 }
 


### PR DESCRIPTION
## Summary
- propagate usage metadata from the AI stream to include provider, model, and cost information so downstream consumers can access token counts.
- update the chat client, usage store, and IndexedDB persistence to read the new usage metadata and keep session totals.
- refresh the usage UI to show the new token fields, handle optional model pricing, and load historical data via the shared database helper.

## Testing
- pnpm typecheck
- pnpm test


------
https://chatgpt.com/codex/tasks/task_e_68e595ea7ac883258632f778a2e77eec